### PR TITLE
Implemented regenerateIf option

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,9 @@ const cachedFunction = makeCacheable(hardToComputeFunction, {
   ttlRandomFactor: 0.5, // TTL = ttl +- ttl * ttlRandomFactor
   key: (param1, param2) => {
     return 'unique-cache-key-for-the-received-params';
+  },
+  regenerateIf: (param1, param2) => {
+    return param1 === 'always refresh cache for this value';
   }
 });
 

--- a/spec/index.spec.js
+++ b/spec/index.spec.js
@@ -21,16 +21,12 @@ function createFakeCacheClient({ fakeCacheGet, fakeCacheSet, cached } = {}) {
   // We need segments to be valid in order to test
   cacheClient.validateSegmentName.and.returnValue(null);
 
-  let dropped = false;
-  const cachedValue = cached && !dropped ? { item: cached } : null;
+  const cachedValue = cached ? { item: cached } : cached;
   /* eslint-disable no-param-reassign */
   fakeCacheGet = fakeCacheGet || ((key, callback) => callback(null, cachedValue));
   fakeCacheSet = fakeCacheSet || ((key, value, ttl, callback) => callback());
   /* eslint-enable */
-  const fakeCacheDrop = (key, callback) => {
-    dropped = true;
-    callback();
-  };
+  const fakeCacheDrop = (key, callback) => callback();
 
   cacheClient.get.and.callFake(fakeCacheGet);
   cacheClient.set.and.callFake(fakeCacheSet);


### PR DESCRIPTION
This will allow the removal of specific keys if certain conditions are met. For example, it will allow the regeneration of the caches for all requests in a specific client request.